### PR TITLE
Replace build.js with build.sh

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -17,5 +17,5 @@ html rendering functions
 ** highlight.js
 syntax highlighter (for smilebasic)
 
-** build.js
+** build.sh
 build script (optional)


### PR DESCRIPTION
This fixes a typo on line 20, where 'build.js' is mentioned instead of 'build.sh'.
build.js does not exist in this repository and as such, I believe this to be a typo.